### PR TITLE
Extend the Sales Item Availability Report (Issue #73)

### DIFF
--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -127,7 +127,7 @@ def get_columns(filters):
             "label": _("F"),
             "fieldname": "F",
             "fieldtype": "Data",
-            "width": 110
+            "width": 130
         },
     ]
 
@@ -201,6 +201,7 @@ def get_data(filters):
 
     # Tag arrays
     strong = {"markup": "strong", "style": ""}
+    strong_gray = {"markup": "strong", "style": "color: darkgray"}
 
     qty_plenty1_strong = [
         {"markup": "span", "style": quantity_style_plenty_1}, strong]
@@ -314,6 +315,18 @@ def get_data(filters):
             "G": ""
         }
 
+        explanation_f = html_wrap(_("Possible - Total Sold"), [strong_gray])
+
+        row_explanation = {
+            "A": "",
+            "B": "",
+            "C": "",
+            "D": "",
+            "E": "",
+            "F": explanation_f,
+            "G": ""
+        }
+
         # Declare the columns where we will place the total sold data
         total_sold_column = "E"
         total_difference_column = "F"
@@ -322,6 +335,7 @@ def get_data(filters):
         data.append(row_header)
         header_idx = len(data) - 1  # track the header index for updates later
         data.append(row_sub_header)
+        data.append(row_explanation)
 
         # Initialize the total sold items in the target uom
         total_target_uom_sold = 0

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -450,8 +450,13 @@ def get_data(filters):
                 pass
 
         # Add the target uom total to the header
-        data[header_idx][total_sold_column] = quantity_style_sold_1 + \
-            str(total_target_uom_sold) + quantity_style_sold_2
+        data[header_idx][total_sold_column] = quantity_style_sold_dk_1 + \
+            str(total_target_uom_sold) + quantity_style_sold_dk_2
+
+        # Add the target uom total difference to the header
+        data[header_idx][total_difference_column] = quantity_style_estimate_1 + \
+            str(material_amount - total_target_uom_sold) + \
+            quantity_style_estimate_2
 
         # We add an empty row after a set of products for easier reading.
         data.append(empty_row)

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -311,10 +311,10 @@ def get_data(filters):
         row_header = {
             "A": estimation_name,
             "B": material_amount_html,
-            "C": _(available_material['amount_uom']),
-            "D": _("Total Sold"),
+            "C": _(f'{uom_name}'),
+            "D": _(f'Total {uom_name} Sold'),
             "E": "",
-            "F": _(available_material['amount_uom']),
+            "F": "",
             "G": ""
         }
         # We add bold style to the subtitles for the headers.

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -398,8 +398,11 @@ def get_data(filters):
                         quantity_sales_item_html = quantity_style_plenty_1 + \
                             str(math.floor(possible_quantity)) + \
                             quantity_style_plenty_2
-                        sales_item_route = item_link_open + \
-                            str(pair['sales_item_code']) + item_link_open_end + \
+
+                        # Build the item code url
+                        item_code = pair['sales_item_code']
+                        sales_item_route = f"{item_link_open}/{item_code}'" + \
+                            item_link_style + item_link_open_end + \
                             str(pair['sales_item_code'][-4:]) + item_link_close
 
                         # Calculate the amount sold

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -161,16 +161,6 @@ def get_data(filters):
       width: 100%;
     """
 
-    quantity_style_sold_dk_1 = """
-      color: white;
-      background-color: darkgreen;
-      display: block;
-      text-align: center;
-      vertical-align: middle;
-      height: 100%;
-      width: 100%;
-    """
-
     quantity_style_plenty_1 = """
       color: black;
       background-color: orange;
@@ -198,6 +188,32 @@ def get_data(filters):
       height: 100%;
       width: 100%;
     """
+
+    quantity_style_sold_dk_1 = """
+      color: white;
+      background-color: darkgreen;
+      display: block;
+      text-align: center;
+      vertical-align: middle;
+      height: 100%;
+      width: 100%;
+    """
+
+    # Tag arrays
+    strong = {"markup": "strong", "style": ""}
+
+    qty_plenty1_strong = [
+        {"markup": "span", "style": quantity_style_plenty_1}, strong]
+
+    qty_estimate1_strong = [
+        {"markup": "span", "style": quantity_style_estimate_1}, strong]
+    
+    qty_sold1_strong = [
+        {"markup": "span", "style": quantity_style_sold_1}, strong]
+
+    qty_sold1_dk_strong = [
+        {"markup": "span", "style": quantity_style_sold_dk_1}, strong]
+    
 
     item_link_open = "<a href='#Form/Item"
     item_link_style = "style='color: #1862AA;'"

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -286,7 +286,7 @@ def get_data(filters):
         material_amount = available_material['amount']
 
         material_amount_html = html_wrap(
-            str(material_amount), ["span", "strong"], quantity_style_plenty_1)
+            str(material_amount), qty_plenty1_strong)
         row_header = {
             "A": estimation_name,
             "B": material_amount_html,
@@ -297,12 +297,12 @@ def get_data(filters):
             "G": ""
         }
         # We add bold style to the subtitles for the headers.
-        col_a = html_wrap(_("Code"), ["strong"])
-        col_b = html_wrap(_("Name"), ["strong"])
-        col_c = html_wrap(_("Possible"), ["strong"])
-        col_d = html_wrap(_("UOM"), ["strong"])
-        col_e = html_wrap(_("Sold"), ["strong"])
-        col_f = html_wrap(_("Available"), ["strong"])
+        col_a = html_wrap(_("Code"), [strong])
+        col_b = html_wrap(_("Name"), [strong])
+        col_c = html_wrap(_("Possible"), [strong])
+        col_d = html_wrap(_("UOM"), [strong])
+        col_e = html_wrap(_("Sold"), [strong])
+        col_f = html_wrap(_("Available"), [strong])
 
         row_sub_header = {
             "A": col_a,
@@ -362,7 +362,6 @@ def get_data(filters):
                 if ms_item['stock_uom'] != available_material['amount_uom']:
 
                     # Reinitialize variables
-                    target_uom_sold = 0
                     item_code = ""
 
                     # find conversion factor , from unit is available material amount_uom - INSERT QUERY CALL HERE
@@ -398,8 +397,9 @@ def get_data(filters):
                         possible_uom = _(ms_item['sales_item_uom'])
 
                         # Add HTML and CSS styles to certain fields
-                        quantity_sales_item_html = html_wrap(str(math.floor(possible_quantity)), [
-                                                             "span", "strong"], quantity_style_plenty_1)
+                        pos_qty = str(math.floor(possible_quantity))
+                        quantity_sales_item_html = html_wrap(
+                            pos_qty, qty_plenty1_strong)
 
                         # Build the item code url
                         item_code = ms_item['sales_item_code']
@@ -419,19 +419,14 @@ def get_data(filters):
 
                         # Add HTML to the sold quantity
                         quantity_sold_html = html_wrap(
-                            str(sold_quantity), ["span", "strong"], quantity_style_sold_1)
+                            str(sold_quantity), qty_sold1_strong)
 
                         # Calculate the difference of possible and sold items
                         available_quantity = int(
                             possible_quantity - sold_quantity)
 
                         available_quantity_html = html_wrap(
-                            str(adjusted_quantity), ["span", "strong"], quantity_style_plenty_1)
-
-                        # Total target uom for this sales item
-                        conversion = ms_item['conversion_factor'][0]['value']
-                        target_uom_sold = (
-                            sold_quantity * ms_item['stock_qty']) / conversion
+                            str(adjusted_quantity), qty_plenty1_strong)
 
                         # Populate the row
                         sales_item_row = {
@@ -445,9 +440,6 @@ def get_data(filters):
                         }
                         data.append(sales_item_row)
 
-                        # modify the header var with the total in the target amt
-                        total_target_uom_sold += target_uom_sold
-
                 else:
                     print('Units are the same, no need for conversion.')
             else:
@@ -455,12 +447,12 @@ def get_data(filters):
 
         # Add the target uom total to the header
         data[header_idx][total_sold_column] = html_wrap(
-            str(total_target_uom_sold), ['span', 'strong'], quantity_style_sold_dk_1)
+            str(total_uom_sold), qty_sold1_dk_strong)
 
         # Add the target uom total difference to the header
-        total_uom_diff = str(material_amount - total_target_uom_sold)
+        total_uom_diff = str(material_amount - total_uom_sold)
         data[header_idx][total_difference_column] = html_wrap(
-            total_uom_diff, ["span", "strong"], quantity_style_estimate_1)
+            total_uom_diff, qty_estimate1_strong)
 
         # We add an empty row after a set of products for easier reading.
         data.append(empty_row)

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -201,7 +201,7 @@ def get_data(filters):
 
     # Tag arrays
     strong = {"markup": "strong", "style": ""}
-    strong_gray = {"markup": "strong", "style": "color: darkgray"}
+    strong_gray = {"markup": "strong", "style": "color: #686868"}
 
     qty_plenty1_strong = [
         {"markup": "span", "style": quantity_style_plenty_1}, strong]

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -15,7 +15,18 @@ import pandas as pd
 import numpy as np
 import math
 
-from revelare.revelare.report.sales_item_availability.sales_item_availability_queries import item_availability_estimates_range, periods_estimated_items, estimation_item_attributes, find_bom_items, find_boms, find_sales_items, find_conversion_factor, find_sales_orders, find_sales_order_items
+from revelare.revelare.report.sales_item_availability.sales_item_availability_queries import (
+  item_availability_estimates_range, 
+  periods_estimated_items, 
+  estimation_item_attributes, 
+  find_bom_items, find_boms, 
+  find_sales_items, 
+  find_conversion_factor, 
+  find_sales_orders, 
+  find_sales_order_items,
+  total_item_availability_estimates,
+  total_item_availability_estimate_attributes
+)
 
 
 def execute(filters=None):
@@ -89,31 +100,31 @@ def get_columns(filters):
             "label": _("B"),
             "fieldname": "B",
             "fieldtype": "Data",
-            "width": 90
+            "width": 120
         },
         {
             "label": _("C"),
             "fieldname": "C",
             "fieldtype": "Data",
-            "width": 90
+            "width": 110
         },
         {
             "label": _("D"),
             "fieldname": "D",
             "fieldtype": "Data",
-            "width": 90
+            "width": 110
         },
         {
             "label": _("E"),
             "fieldname": "E",
             "fieldtype": "Data",
-            "width": 90
+            "width": 110
         },
         {
             "label": _("F"),
             "fieldname": "F",
             "fieldtype": "Data",
-            "width": 90
+            "width": 110
         },
     ]
 

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -16,17 +16,20 @@ import numpy as np
 import math
 
 from revelare.revelare.report.sales_item_availability.sales_item_availability_queries import (
-  item_availability_estimates_range, 
-  periods_estimated_items, 
-  estimation_item_attributes, 
-  find_bom_items, find_boms, 
-  find_sales_items, 
-  find_conversion_factor, 
-  find_sales_orders, 
-  find_sales_order_items,
-  total_item_availability_estimates,
-  total_item_availability_estimate_attributes
+    item_availability_estimates_range,
+    periods_estimated_items,
+    estimation_item_attributes,
+    find_bom_items, find_boms,
+    find_sales_items,
+    find_conversion_factor,
+    find_sales_orders,
+    find_sales_order_items,
+    total_item_availability_estimates,
+    total_item_availability_estimate_attributes,
+    total_sales_items
 )
+
+from revelare.revelare.report.sales_item_availability.sales_item_availability_utils import html_wrap
 
 
 def execute(filters=None):
@@ -145,48 +148,61 @@ def get_data(filters):
     # --------- EMPTY ROW ----------
     empty_row = {}
     data = [empty_row]
+
     # --------- STYLES DEIFNITIONS BEGIN ----------
-    quantity_style_estimate_1 = "<span style='color: white; background-color: darkorange; display: block; text-align: center; vertical-align: middle; height: 100%; width: 100%;'><strong>"
-    quantity_style_estimate_2 = "</strong></span>"
-    quantity_style_sold_dk_1 = "<span style='color: white; background-color: darkgreen;  display: block; text-align: center; vertical-align: middle; height: 100%; width: 100%;'><strong>"
-    quantity_style_sold_dk_2 = "</strong></span>"
-    quantity_style_plenty_1 = "<span style='color: black; background-color: orange; float: right; text-align: right; vertical-align: middle; height: 100%; width: 100%;'><strong>"
-    quantity_style_plenty_2 = "</strong></span>"
-    quantity_style_few_1 = "<span style='color: black; background-color: blue; float: right; text-align: right; vertical-align: text-top;'><strong>"
-    quantity_style_few_2 = "</strong></span>"
-    quantity_style_sold_1 = "<span style='color: black; background-color: #60A917; float: right; text-align: right; vertical-align: middle; height: 100%; width: 100%;'><strong>"
-    quantity_style_sold_2 = "</strong></span>"
-    item_link_open = "<a href='#Form/Item/' style='color: #1862AA;'"
+    # Styles
+    quantity_style_estimate_1 = """
+      color: white;
+      background-color: darkorange;
+      display: block;
+      text-align: center;
+      vertical-align: middle;
+      height: 100%;
+      width: 100%;
+    """
+
+    quantity_style_sold_dk_1 = """
+      color: white;
+      background-color: darkgreen;
+      display: block;
+      text-align: center;
+      vertical-align: middle;
+      height: 100%;
+      width: 100%;
+    """
+
+    quantity_style_plenty_1 = """
+      color: black;
+      background-color: orange;
+      float: right;
+      text-align: right;
+      vertical-align: middle;
+      height: 100%;
+      width: 100%;
+    """
+
+    quantity_style_few_1 = """
+      color: black;
+      background-color: blue;
+      float: right;
+      text-align: right;
+      vertical-align: text-top;
+    """
+
+    quantity_style_sold_1 = """
+      color: black;
+      background-color: #60A917;
+      float: right;
+      text-align: right;
+      vertical-align: middle;
+      height: 100%;
+      width: 100%;
+    """
+
+    item_link_open = "<a href='#Form/Item"
+    item_link_style = "style='color: #1862AA;'"
     item_link_open_end = " target='_blank'>"
     item_link_close = "</a>"
-
-    # quantity_material = quantity_style_plenty_1 + \
-    #     str(35) + quantity_style_plenty_2
-    # quantity_sales_item = quantity_style_plenty_1 + \
-    #     str(70) + quantity_style_plenty_2
-    # row1 = {
-    #     "A": "Albahaca",
-    #     "B": quantity_material,
-    #     "C": "Pound",
-    #     "D": "7401168800724",
-    #     "E": "Albahaca 8Oz",
-    #     "F": quantity_sales_item
-    # }
-
-    # ----- QUERY # 1 BEGIN -----
-    # Obtain Valid Item Availability Estimates for dates from our query functions.
-    estimates = item_availability_estimates_range(filters)
-
-    # Just the name
-    # estimate_data = estimates[0]['name']
-
-    # en: We create an empty list where we will add Item Availability Estimate doctype names
-    # es-GT: Creamos una lista vacia para luego agregar los nombres de los doctypes de Estimados de Disponibilidad
-    iae_list = []
-    # we now add them
-    for x in estimates:
-        iae_list.append(x['name'])
-    # ----- QUERY # 1 END -----
 
     # ----- QUERY # 2 BEGIN -----
     # We are now ready to assemble a list of Material items, for those IAE names that fit date filters.

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -260,26 +260,33 @@ def get_data(filters):
     sales_item_codes = [item['item_code']
                         for item in matching_sales_order_items]
 
-        material_amount_html = quantity_style_plenty_1 + \
-            str(available_material['amount']) + quantity_style_plenty_2
+    # ----- PROCESS DATA BEGIN -----
+    # Iterate over the list of item estimates, including items from matching
+    # sales orders and converting units to the target uom
+    for available_material in estimated_materials_with_attributes:
+        # en: We build and add the "grouping row"
+        estimation_name = available_material['estimation_name']
+        uom_name = available_material["amount_uom"]
+        material_amount = available_material['amount']
+
+        material_amount_html = html_wrap(
+            str(material_amount), ["span", "strong"], quantity_style_plenty_1)
         row_header = {
             "A": estimation_name,
             "B": material_amount_html,
-            "C": _(f'{uom_name}'),
-            "D": _(f'Total {uom_name} Sold'),
+            "C": _(f"{uom_name}"),
+            "D": _(f"Total {uom_name} Sold"),
             "E": "",
             "F": "",
             "G": ""
         }
         # We add bold style to the subtitles for the headers.
-        bld_start = "<strong>"
-        bld_end = "</strong>"
-        col_a = bld_start + _("Code") + bld_end
-        col_b = bld_start + _("Name") + bld_end
-        col_c = bld_start + _("Possible") + bld_end
-        col_d = bld_start + _("UOM") + bld_end
-        col_e = bld_start + _("Sold") + bld_end
-        col_f = bld_start + _("Available") + bld_end
+        col_a = html_wrap(_("Code"), ["strong"])
+        col_b = html_wrap(_("Name"), ["strong"])
+        col_c = html_wrap(_("Possible"), ["strong"])
+        col_d = html_wrap(_("UOM"), ["strong"])
+        col_e = html_wrap(_("Sold"), ["strong"])
+        col_f = html_wrap(_("Available"), ["strong"])
 
         row_sub_header = {
             "A": col_a,
@@ -349,9 +356,8 @@ def get_data(filters):
                             possible_uom = _(pair['sales_item_uom'])
 
                         # Add HTML and CSS styles to certain fields
-                        quantity_sales_item_html = quantity_style_plenty_1 + \
-                            str(math.floor(possible_quantity)) + \
-                            quantity_style_plenty_2
+                        quantity_sales_item_html = html_wrap(str(math.floor(possible_quantity)), [
+                                                             "span", "strong"], quantity_style_plenty_1)
 
                         # Build the item code url
                         item_code = pair['sales_item_code']
@@ -369,8 +375,8 @@ def get_data(filters):
                             sold_quantity = 0
 
                         # Add HTML to the sold quantity
-                        quantity_sold_html = quantity_style_sold_1 + \
-                            str(sold_quantity) + quantity_style_sold_2
+                        quantity_sold_html = html_wrap(
+                            str(sold_quantity), ["span", "strong"], quantity_style_sold_1)
 
                         # Calculate the difference of possible and sold items
                         available_quantity = int(

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -146,6 +146,10 @@ def get_data(filters):
     empty_row = {}
     data = [empty_row]
     # --------- STYLES DEIFNITIONS BEGIN ----------
+    quantity_style_estimate_1 = "<span style='color: white; background-color: darkorange; display: block; text-align: center; vertical-align: middle; height: 100%; width: 100%;'><strong>"
+    quantity_style_estimate_2 = "</strong></span>"
+    quantity_style_sold_dk_1 = "<span style='color: white; background-color: darkgreen;  display: block; text-align: center; vertical-align: middle; height: 100%; width: 100%;'><strong>"
+    quantity_style_sold_dk_2 = "</strong></span>"
     quantity_style_plenty_1 = "<span style='color: black; background-color: orange; float: right; text-align: right; vertical-align: middle; height: 100%; width: 100%;'><strong>"
     quantity_style_plenty_2 = "</strong></span>"
     quantity_style_few_1 = "<span style='color: black; background-color: blue; float: right; text-align: right; vertical-align: text-top;'><strong>"

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -222,19 +222,13 @@ def get_data(filters):
     item_link_close = "</a>"
 
     # ----- QUERY # 1 BEGIN -----
-    # Obtain Valid Item Availability Estimates for dates from our query functions.
-    # [{'item_code': 'CULTIVO-0069', 'amount':'15.0', 'amount_uom': 'Pound'}]
-    # We want unique item codes and amounts, such that each material item estimate is included only ONCE.
-    estimated_material_list = total_item_availability_estimates(filters)
-
-    # ----- QUERY # 2 BEGIN -----
     # We now create a list of estimation item attributes
     # [{'name': 'CULTIVO-0069', 'estimation_name': 'Perejil', 'estimation_uom': 'Pound', 'stock_uom': 'Onza', 'amount':'15.0', 'amount_uom': 'Pound'}]
     # This list is already "filtered" and curated to include all the REQUESTED estimation item codes and attributes
     estimated_materials_with_attributes = total_item_availability_estimate_attributes(
         filters)
 
-    # ----- QUERY # 3 BEGIN -----
+    # ----- QUERY # 2 BEGIN -----
     # Now we find the BOM names based on the names of material items in our item_attributes_list
     # [{'item_code': 'CULTIVO-0069', 'parent': 'BOM-7401168802186-001', 'stock_qty': 6.0, 'stock_uom': 'Onza'}]
     bom_items_list = []
@@ -243,7 +237,7 @@ def get_data(filters):
         bom_items = find_bom_items(filters, material_doctype_name)
         bom_items_list.extend(bom_items)
 
-    # ----- QUERY # 4 BEGIN -----
+    # ----- QUERY # 3 BEGIN -----
     # we get sales item code, quantity obtained, and uom obtained for each bom parent.
     material_and_sales_items = []
     for bom_item in bom_items_list:
@@ -263,7 +257,7 @@ def get_data(filters):
         # Append it to the list of sales items
         material_and_sales_items.append(bom_item)
 
-    # ----- QUERY # 5 BEGIN -----
+    # ----- QUERY # 4 BEGIN -----
     # Sales Order query, return all sales order names that fit within
     # the dates in report filter
     matching_sales_order_items = total_sales_items(filters)

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -322,6 +322,10 @@ def get_data(filters):
             "G": ""
         }
 
+        # Declare the column where we will place the total sold quantity
+        total_sold_column = "E"
+
+        # Set the header and subheader values
         data.append(row_header)
         header_idx = len(data) - 1  # track the header idx for updates later
         data.append(row_sub_header)
@@ -428,7 +432,7 @@ def get_data(filters):
                 pass
 
         # Add the target uom total to the header
-        data[header_idx]["E"] = quantity_style_sold_1 + \
+        data[header_idx][total_sold_column] = quantity_style_sold_1 + \
             str(total_target_uom_sold) + quantity_style_sold_2
 
         # We add an empty row after a set of products for easier reading.

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
@@ -25,6 +25,29 @@ def total_item_availability_estimates(filters):
   )
   return result
 
+def total_item_availability_estimate_attributes(filters):
+  """
+  Returns a list of dictionaries that contain the item availability estimate
+  name, estimation name, estimation uom, stock uom, total amount, amount uom
+  """
+  result = frappe.db.sql(
+    f"""
+    SELECT name, estimation_name, estimation_uom, stock_uom, 
+                 estimate.item_name, estimate.amount, estimate.amount_uom
+    FROM `tabItem` 
+    INNER JOIN (SELECT ei.item_code, ei.item_name, SUM(ei.amount) as amount, ei.amount_uom
+          FROM `tabItem Availability Estimate` as iae
+          INNER JOIN `tabEstimated Item` as ei 
+          ON iae.name = ei.parent
+          WHERE iae.docstatus = 1 
+          AND ei.docstatus = 1
+          AND (iae.start_date AND iae.end_date BETWEEN '2020-10-01' and '2020-10-31')
+          GROUP BY ei.item_code) as estimate
+    WHERE name=estimate.item_code;
+    """, as_dict=True
+  )
+  return result;
+
 def item_availability_estimates_range(filters):
     """Function that returns the name of the submitted Item Availability Estimates
     that fall between the dates selected in the filter.

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
@@ -53,15 +53,13 @@ def total_item_availability_estimate_attributes(filters):
 def total_sales_items(filters):
   result = frappe.db.sql(
     f"""
-    SELECT soi.item_name, soi.item_code, soi.delivery_date, 
+    SELECT soi.item_code, soi.delivery_date, 
 	         SUM(soi.stock_qty) as stock_qty, soi.stock_uom 
     FROM `tabSales Order Item` as soi
-    INNER JOIN
+    WHERE soi.parent IN
       (SELECT so.name FROM `tabSales Order` AS so 
-        WHERE docstatus=1 
-        AND (delivery_date 
-             BETWEEN '{filters.from_date}' AND '{filters.to_date}')) as sonames
-    ON sonames.name=soi.parent
+        WHERE so.docstatus=1 
+        AND (delivery_date BETWEEN '{filters.from_date}' AND '{filters.to_date}'))
     GROUP BY soi.item_code;
     """, as_dict=True
   )

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
@@ -5,6 +5,25 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _, _dict, scrub
 
+def total_item_availability_estimates(filters):
+  """
+  Returns a list of dictionaries that contain the sum of item availability
+  estimate name, amounts and uom that fall within a date range
+  """
+  result = frappe.db.sql(
+      f"""
+      SELECT ei.item_code, SUM(ei.amount) as amount, ei.amount_uom
+      FROM `tabItem Availability Estimate` as iae
+      INNER JOIN `tabEstimated Item` as ei 
+      ON iae.name = ei.parent
+      WHERE iae.docstatus = 1 
+      AND ei.docstatus = 1
+      AND (iae.start_date AND iae.end_date 
+           BETWEEN '{filters.from_date}' AND '{filters.to_date}')
+      GROUP BY ei.item_code;
+      """, as_dict=True
+  )
+  return result
 
 def item_availability_estimates_range(filters):
     """Function that returns the name of the submitted Item Availability Estimates

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
@@ -50,6 +50,23 @@ def total_item_availability_estimate_attributes(filters):
   )
   return result
 
+def total_sales_items(filters):
+  result = frappe.db.sql(
+    f"""
+    SELECT soi.item_name, soi.item_code, soi.delivery_date, 
+	         SUM(soi.stock_qty) as stock_qty, soi.stock_uom 
+    FROM `tabSales Order Item` as soi
+    INNER JOIN
+      (SELECT so.name FROM `tabSales Order` AS so 
+        WHERE docstatus=1 
+        AND (delivery_date 
+             BETWEEN '{filters.from_date}' AND '{filters.to_date}')) as sonames
+    ON sonames.name=soi.parent
+    GROUP BY soi.item_code;
+    """, as_dict=True
+  )
+  return result
+
 def item_availability_estimates_range(filters):
     """Function that returns the name of the submitted Item Availability Estimates
     that fall between the dates selected in the filter.

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
@@ -35,18 +35,20 @@ def total_item_availability_estimate_attributes(filters):
     SELECT name, estimation_name, estimation_uom, stock_uom, 
                  estimate.item_name, estimate.amount, estimate.amount_uom
     FROM `tabItem` 
-    INNER JOIN (SELECT ei.item_code, ei.item_name, SUM(ei.amount) as amount, ei.amount_uom
-          FROM `tabItem Availability Estimate` as iae
-          INNER JOIN `tabEstimated Item` as ei 
-          ON iae.name = ei.parent
-          WHERE iae.docstatus = 1 
-          AND ei.docstatus = 1
-          AND (iae.start_date AND iae.end_date BETWEEN '2020-10-01' and '2020-10-31')
-          GROUP BY ei.item_code) as estimate
+    INNER JOIN 
+      (SELECT ei.item_code, ei.item_name, SUM(ei.amount) as amount, ei.amount_uom
+       FROM `tabItem Availability Estimate` as iae
+       INNER JOIN `tabEstimated Item` as ei 
+       ON iae.name = ei.parent
+       WHERE iae.docstatus = 1 
+       AND ei.docstatus = 1
+       AND (iae.start_date AND iae.end_date 
+            BETWEEN '{filters.from_date}' AND '{filters.to_date}')
+       GROUP BY ei.item_code) as estimate
     WHERE name=estimate.item_code;
     """, as_dict=True
   )
-  return result;
+  return result
 
 def item_availability_estimates_range(filters):
     """Function that returns the name of the submitted Item Availability Estimates

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_utils.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_utils.py
@@ -1,0 +1,24 @@
+def html_wrap(txt: str, tags: list, style: str = "") -> str:
+    """
+    Wrap text in an html tag and return as a string
+      Args:
+        txt*: The text to wrap in html
+        tags*: The html tags without brackets, outward in order
+        style: Any inline styles to include 
+    """
+    # Remove any newlines to allow it to render equally in all browsers
+    replacements = {"\n": "", "\t": "", "  ": ""}
+    if style:
+        for old, new in replacements.items():
+            style = style.replace(old, new)
+
+    # Wrap the tags in order, from inside out, then apply styles to outmost tag
+    wrapped = txt
+    while tags:
+        tag = tags.pop()
+        if len(tags):
+            wrapped = f"<{tag}>{wrapped}</{tag}>"
+        else:
+            wrapped = f"<{tag} style='{style}'>{wrapped}</{tag}>"
+
+    return wrapped

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_utils.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_utils.py
@@ -1,27 +1,36 @@
-def html_wrap(txt: str, tags: list, style: str = "") -> str:
+def html_wrap(txt: str, tags: list) -> str:
     """
-    Wrap text in an html tag and return as a string
+    Wrap text in one or more html tags and return as a string
       Args:
         txt*: The text to wrap in html
         tags*: The html tags without brackets, outward in order
-        style: Any inline styles to include 
+      
+      Tags should have a shape like the following example:
+        {
+          markup: 'p',
+          style: 'color: white;'
+        }
     """
-    # Remove any newlines to allow it to render equally in all browsers
+    # Remove any unwantted chars to allow css to render equally in all browsers
     replacements = {"\n": "", "\t": "", "  ": ""}
-    if style:
-        for old, new in replacements.items():
-            style = style.replace(old, new)
 
-    # Wrap the tags in order, from inside out, then apply styles to outmost tag
+    # Wrap the tags in order, from inside out, applying styles to each tag
     wrapped = txt
-    while tags:
-        tag = tags.pop()
-        if len(tags):
-            wrapped = f"<{tag}>{wrapped}</{tag}>"
-        else:
-            wrapped = f"<{tag} style='{style}'>{wrapped}</{tag}>"
+    tags_to_wrap = tags.copy()
+    while tags_to_wrap:
+        # Grab the tag
+        tag = tags_to_wrap.pop()
+        markup = tag["markup"]
+        style = format_style(tag["style"], replacements)
 
+        # Wrap each level of the html in the tag 
+        if len(style):
+            wrapped = f"<{markup} style='{style}'>{wrapped}</{markup}>"
+        else:
+            wrapped = f"<{markup}>{wrapped}</{markup}>"
+            
     return wrapped
+
 def format_style(style: str, replacements: list) -> str:
   """
   Remove unwanted characters from the style, such as newlines, tabs and spaces

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_utils.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_utils.py
@@ -22,3 +22,13 @@ def html_wrap(txt: str, tags: list, style: str = "") -> str:
             wrapped = f"<{tag} style='{style}'>{wrapped}</{tag}>"
 
     return wrapped
+def format_style(style: str, replacements: list) -> str:
+  """
+  Remove unwanted characters from the style, such as newlines, tabs and spaces
+  """
+  formatted_style = style
+  if formatted_style:
+      for old, new in replacements.items():
+          formatted_style = formatted_style.replace(old, new)
+  
+  return formatted_style


### PR DESCRIPTION
This pull request is to resolve issue #73. I made the following changes to the project to resolve this issue:

1. **I added a total sold column to the report that totaled the sold items in Pounds**

2. **Increased column widths as per the specification**

3. **Consolidated multiple queries and query helpers into single SQL queries**
I wrote SQL queries that performed the same purpose as some of the pre-existing SELECT queries and functions that would then combine or chain query results together. By using SQL subqueries, I was able to select the results of one of the prior queries and use that data in a second query, without having to use Python functions or store the intermediate results in variables.

4. **The "Total UOM Sold" row header is now dynamic**
The "Total UOM Sold" header is now dynamic, and will read as "Total Pound Sold" if the UOM is Pounds.

5. **Separated strings with a mix of HTML and CSS into valid CSS and HTML objects, and added the `html_wrap` utility function 
to create HTML strings with the specified style(s)**
I converted the existing strings that contained opening and closing HTML tags with inline styles into style objects formatted to be more manageable (as CSS would be written in a stylesheet), and wrote a custom utility function `html_wrap` that can build strings of valid HTML with inline styles using tag objects containing optional styles. This creates a simple, declarative API that allows developers to modify or create styles, embed them in HTML objects, and also compose style and HTML objects. 

6. **Displayed the adjusted available quantity on the report**
I extracted the logic for summing sold items and calculated it once per estimation item rather than combining the totals for each individual sales item sold. This allowed the individual items to reduce the available amounts properly by taking all sold items into account.

7. **Added an explanation row with text for the "Available" column**
As per the issue, I added an extra row per parent estimation item explaining what the "Available" column represents or how it was calculated. 

8. **Miscellaneous styling completed**

The report following the changes displays as shown below:

![revelare sales fix](https://user-images.githubusercontent.com/47503507/100694130-5f12af80-335c-11eb-9ce6-08d8b813ecbf.PNG)
