### PR TITLE
Guard against multiple / repeating BOM items

### DIFF
--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -208,13 +208,12 @@ def get_data(filters):
 
     qty_estimate1_strong = [
         {"markup": "span", "style": quantity_style_estimate_1}, strong]
-    
+
     qty_sold1_strong = [
         {"markup": "span", "style": quantity_style_sold_1}, strong]
 
     qty_sold1_dk_strong = [
         {"markup": "span", "style": quantity_style_sold_dk_1}, strong]
-    
 
     item_link_open = "<a href='#Form/Item"
     item_link_style = "style='color: #1862AA;'"
@@ -240,6 +239,7 @@ def get_data(filters):
     # ----- QUERY # 3 BEGIN -----
     # we get sales item code, quantity obtained, and uom obtained for each bom parent.
     material_and_sales_items = []
+    included_items = set()
     for bom_item in bom_items_list:
         bom_name = bom_item['parent']
         boms = find_boms(filters, bom_name)
@@ -254,8 +254,10 @@ def get_data(filters):
             estimated_materials_with_attributes[0]['amount_uom'], bom_item['stock_uom'])
         bom_item.pop("parent")
 
-        # Append it to the list of sales items
-        material_and_sales_items.append(bom_item)
+        # Append it to the list of sales items if not already included in the report
+        if not boms[0]['item_name'] in included_items:
+            included_items.add(boms[0]['item_name'])
+            material_and_sales_items.append(bom_item)
 
     # ----- QUERY # 4 BEGIN -----
     # Sales Order query, return all sales order names that fit within

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability.py
@@ -246,18 +246,19 @@ def get_data(filters):
 
         # We rearrange the current dictionary, assigning values from returned keys in this list
         # to new keys in this object.
-        bom_item['sales_item_code'] = boms[0]['item']
-        bom_item['sales_item_qty'] = boms[0]['quantity']
-        bom_item['sales_item_uom'] = boms[0]['uom']
-        bom_item['sales_item_name'] = boms[0]['item_name']
-        bom_item['conversion_factor'] = find_conversion_factor(
-            estimated_materials_with_attributes[0]['amount_uom'], bom_item['stock_uom'])
-        bom_item.pop("parent")
+        if len(boms):
+            bom_item['sales_item_code'] = boms[0]['item']
+            bom_item['sales_item_qty'] = boms[0]['quantity']
+            bom_item['sales_item_uom'] = boms[0]['uom']
+            bom_item['sales_item_name'] = boms[0]['item_name']
+            bom_item['conversion_factor'] = find_conversion_factor(
+                estimated_materials_with_attributes[0]['amount_uom'], bom_item['stock_uom'])
+            bom_item.pop("parent")
 
-        # Append it to the list of sales items if not already included in the report
-        if not boms[0]['item_name'] in included_items:
-            included_items.add(boms[0]['item_name'])
-            material_and_sales_items.append(bom_item)
+            # Append it to the list of sales items if not already included in the report
+            if not boms[0]['item_name'] in included_items:
+                included_items.add(boms[0]['item_name'])
+                material_and_sales_items.append(bom_item)
 
     # ----- QUERY # 4 BEGIN -----
     # Sales Order query, return all sales order names that fit within

--- a/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
+++ b/revelare/revelare/report/sales_item_availability/sales_item_availability_queries.py
@@ -127,7 +127,10 @@ def find_bom_items(filters, estimation_item_code):
     """
     result = frappe.db.sql(
         f"""
-        SELECT item_code, parent, stock_qty, stock_uom FROM `tabBOM Item` WHERE item_code='{estimation_item_code}';
+        SELECT item_code, parent, stock_qty, stock_uom 
+        FROM `tabBOM Item` 
+        WHERE item_code='{estimation_item_code}'
+        AND docstatus=1;
         """, as_dict=True
     )
     return result
@@ -142,7 +145,10 @@ def find_boms(filters, bom):
     """
     result = frappe.db.sql(
         f"""
-        SELECT item, quantity, uom, item_name FROM `tabBOM` WHERE name='{bom}';
+        SELECT item, quantity, uom, item_name 
+        FROM `tabBOM` 
+        WHERE name='{bom}'
+        AND docstatus=1;
         """, as_dict=True
     )
     return result


### PR DESCRIPTION
I added logic to the report to prevent BOM item repetition in the report when there are multiple BOMs for a sales item. I took two approaches to add additional robustness for two potential edge cases:

1) There are multiple BOMs, but only 1 is active. The rest are cancelled.
2) There are multiple BOMs, and more than 1 is active.

Case 1 seems to occur organically as users interact with the report and doctypes. Case 2 seems like it would be a rare occurrence but it was added in case of a user potentially adding a second BOM without realizing one already existed, and then not cancelling the second BOM.